### PR TITLE
WIP: Add JUnit 5 tests and implement domain classes for multi-datasou…

### DIFF
--- a/multi-datasource/pom.xml
+++ b/multi-datasource/pom.xml
@@ -72,10 +72,33 @@
             <version>6.0.6</version>
         </dependency>
 
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/multi-datasource/src/main/java/org/hqf/tutorials/spring/domain/User.java
+++ b/multi-datasource/src/main/java/org/hqf/tutorials/spring/domain/User.java
@@ -1,8 +1,42 @@
 package org.hqf.tutorials.spring.domain;
 
-/**
- * @author huoquanfu
- * @date 2019/03/18
- */
 public class User {
+
+    private Long id;
+    private String name;
+    private int age;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    // Optional: toString, equals, hashCode methods can be added if needed
+    @Override
+    public String toString() {
+        return "User{" +
+               "id=" + id +
+               ", name='" + name + '\'' +
+               ", age=" + age +
+               '}';
+    }
 }

--- a/multi-datasource/src/test/java/org/hqf/tutorials/spring/DynamicDataSourceTest.java
+++ b/multi-datasource/src/test/java/org/hqf/tutorials/spring/DynamicDataSourceTest.java
@@ -1,0 +1,68 @@
+package org.hqf.tutorials.spring;
+
+import org.hqf.tutorials.spring.constants.DataSourceTypeEnum;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DynamicDataSourceTest {
+
+    private DynamicDataSource dynamicDataSource;
+
+    @BeforeEach
+    void setUp() {
+        dynamicDataSource = new DynamicDataSource();
+        // Clear any existing context before each test
+        JdbcContextHolder.clear(); 
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Ensure context is cleared after each test
+        JdbcContextHolder.clear();
+    }
+
+    @Test
+    void determineCurrentLookupKey_noContextSet() {
+        // When no data source type is set in JdbcContextHolder, 
+        // it should return the default (or null, depending on unmocked AbstractRoutingDataSource behavior)
+        // For this test, we expect null or the default if one were configured in DynamicDataSource.
+        // As per current DynamicDataSource, it will delegate to AbstractRoutingDataSource which might return null.
+        Object key = dynamicDataSource.determineCurrentLookupKey();
+        assertNull(key, "Lookup key should be null when no context is set");
+    }
+
+    @Test
+    void determineCurrentLookupKey_masterSet() {
+        JdbcContextHolder.set(DataSourceTypeEnum.MASTER);
+        Object key = dynamicDataSource.determineCurrentLookupKey();
+        assertEquals(DataSourceTypeEnum.MASTER, key, "Lookup key should be MASTER");
+    }
+
+    @Test
+    void determineCurrentLookupKey_slaveSet() {
+        JdbcContextHolder.set(DataSourceTypeEnum.SLAVE);
+        Object key = dynamicDataSource.determineCurrentLookupKey();
+        assertEquals(DataSourceTypeEnum.SLAVE, key, "Lookup key should be SLAVE");
+    }
+
+    @Test
+    void determineCurrentLookupKey_setAndClear() {
+        JdbcContextHolder.set(DataSourceTypeEnum.MASTER);
+        assertEquals(DataSourceTypeEnum.MASTER, dynamicDataSource.determineCurrentLookupKey(), "Lookup key should be MASTER initially");
+        
+        JdbcContextHolder.clear();
+        assertNull(dynamicDataSource.determineCurrentLookupKey(), "Lookup key should be null after clearing");
+    }
+    
+    @Test
+    void determineCurrentLookupKey_switchSource() {
+        JdbcContextHolder.set(DataSourceTypeEnum.MASTER);
+        assertEquals(DataSourceTypeEnum.MASTER, dynamicDataSource.determineCurrentLookupKey(), "Lookup key should be MASTER");
+        
+        JdbcContextHolder.set(DataSourceTypeEnum.SLAVE);
+        assertEquals(DataSourceTypeEnum.SLAVE, dynamicDataSource.determineCurrentLookupKey(), "Lookup key should be SLAVE after switching");
+    }
+}

--- a/multi-datasource/src/test/java/org/hqf/tutorials/spring/dao/UserDaoImplTest.java
+++ b/multi-datasource/src/test/java/org/hqf/tutorials/spring/dao/UserDaoImplTest.java
@@ -1,0 +1,100 @@
+package org.hqf.tutorials.spring.dao;
+
+import org.hqf.tutorials.spring.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserDaoImplTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private UserDaoImpl userDao;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(1L);
+        user.setName("Test User");
+        user.setAge(30);
+    }
+
+    @Test
+    void insertUser() {
+        when(jdbcTemplate.update(anyString(), any(), any(), any())).thenReturn(1);
+
+        userDao.insertUser(user);
+
+        verify(jdbcTemplate).update(
+            "insert into user(id,name,age) values(?,?,?)",
+            user.getId(),
+            user.getName(),
+            user.getAge()
+        );
+    }
+
+    @Test
+    void updateUser() {
+        when(jdbcTemplate.update(anyString(), any(), any(), any())).thenReturn(1);
+
+        userDao.updateUser(user);
+
+        verify(jdbcTemplate).update(
+            "update user set name =? ,age=? where id=?",
+            user.getName(),
+            user.getAge(),
+            user.getId()
+        );
+    }
+
+    @Test
+    void findUsers() {
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
+            .thenReturn(Collections.singletonList(user));
+
+        List<User> users = userDao.findUsers(user.getId());
+
+        assertNotNull(users);
+        assertEquals(1, users.size());
+        assertEquals(user.getName(), users.get(0).getName());
+        verify(jdbcTemplate).query(
+            eq("select id,name,age from user where id=?"),
+            any(Object[].class),
+            any(RowMapper.class)
+        );
+    }
+    
+    @Test
+    void findUsers_noResult() {
+        when(jdbcTemplate.query(anyString(), any(Object[].class), any(RowMapper.class)))
+            .thenReturn(Collections.emptyList());
+
+        List<User> users = userDao.findUsers(99L); // Non-existent ID
+
+        assertNotNull(users);
+        assertTrue(users.isEmpty());
+        verify(jdbcTemplate).query(
+            eq("select id,name,age from user where id=?"),
+            any(Object[].class),
+            any(RowMapper.class)
+        );
+    }
+}

--- a/multi-datasource/src/test/java/org/hqf/tutorials/spring/service/impl/UserServiceImplTest.java
+++ b/multi-datasource/src/test/java/org/hqf/tutorials/spring/service/impl/UserServiceImplTest.java
@@ -1,29 +1,111 @@
 package org.hqf.tutorials.spring.service.impl;
 
+import org.hqf.tutorials.spring.dao.UserDao;
+import org.hqf.tutorials.spring.domain.User;
 import org.hqf.tutorials.spring.service.UserService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration("classpath:applicationContext.xml")
-public class UserServiceImplTest {
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
 
-    @Resource
-    private UserService userService;
+    @Mock
+    private UserDao userDao;
 
-    @Test
-    public void addUser() {
-        userService.addUser(null);
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        user1 = new User();
+        user1.setId(1L);
+        user1.setName("Test User 1");
+        user1.setAge(30);
+
+        user2 = new User();
+        user2.setId(2L);
+        user2.setName("Test User 2");
+        user2.setAge(25);
     }
 
     @Test
-    public void queryUser() {
-        userService.queryUser(1L);
+    void addUsers() {
+        List<User> users = new ArrayList<>();
+        users.add(user1);
+        users.add(user2);
+
+        // No return value to mock for userDao.insertUser as it's void
+
+        userService.addUsers(users);
+
+        // Verify that userDao.insertUser was called for each user in the list
+        verify(userDao, times(1)).insertUser(user1);
+        verify(userDao, times(1)).insertUser(user2);
+    }
+    
+    @Test
+    void addUsers_emptyList() {
+        List<User> users = Collections.emptyList();
+
+        userService.addUsers(users);
+
+        // Verify that userDao.insertUser was never called
+        verify(userDao, never()).insertUser(any(User.class));
+    }
+
+    @Test
+    void updateUser() {
+        // No return value to mock for userDao.updateUser as it's void
+        userService.updateUser(user1);
+        verify(userDao, times(1)).updateUser(user1);
+    }
+    
+    @Test
+    void updateUser_nullUser() {
+        // Check if the service handles null input gracefully, 
+        // assuming it should not call DAO for null user.
+        // Depending on actual implementation, it might throw NPE or have specific handling.
+        // For this test, we assume it does nothing if user is null.
+        userService.updateUser(null);
+        verify(userDao, never()).updateUser(any(User.class));
+    }
+
+
+    @Test
+    void findUsers() {
+        when(userDao.findUsers(user1.getId())).thenReturn(Collections.singletonList(user1));
+
+        List<User> foundUsers = userService.findUsers(user1.getId());
+
+        assertNotNull(foundUsers);
+        assertEquals(1, foundUsers.size());
+        assertEquals(user1.getName(), foundUsers.get(0).getName());
+        verify(userDao, times(1)).findUsers(user1.getId());
+    }
+    
+    @Test
+    void findUsers_notFound() {
+        Long nonExistentId = 99L;
+        when(userDao.findUsers(nonExistentId)).thenReturn(Collections.emptyList());
+
+        List<User> foundUsers = userService.findUsers(nonExistentId);
+
+        assertNotNull(foundUsers);
+        assertTrue(foundUsers.isEmpty());
+        verify(userDao, times(1)).findUsers(nonExistentId);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,49 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.8.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.8.2</version>
+                <scope>test</scope>
+            </dependency>
+
 
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.2</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>1.3.2</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>


### PR DESCRIPTION
…rce module

This commit includes the following work-in-progress changes:

- Added JUnit 5 dependencies to parent and multi-datasource POM files.
- Configured Maven Surefire plugin for JUnit 5.
- Created unit tests for:
    - UserDaoImpl (mocking JdbcTemplate)
    - UserServiceImpl (mocking UserDao)
    - DynamicDataSource (testing interaction with JdbcContextHolder)
- Implemented the User.java domain class with id, name, and age fields and corresponding getters/setters.

I paused while about to implement JdbcContextHolder.java and DataSourceTypeEnum.java, which are also required to fix test compilation errors. Next steps would be to implement these classes and then re-run the tests.